### PR TITLE
Fix: Set /etc/mailname to a correct value

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,4 +26,12 @@
   when:
     - exim4__configure
   notify: Reload exim4
+
+- name: Set mailname file
+  template:
+    dest: /etc/mailname
+    src: mailname
+    owner: root
+    group: root
+    mode: 0644
 ...

--- a/templates/mailname
+++ b/templates/mailname
@@ -1,0 +1,1 @@
+{{ exim4__conf.mailname }}


### PR DESCRIPTION
This should no be an internal but a valid domain, for managing bounces