### PR TITLE
Fix: Configure well-known instead of well_known location

### DIFF
--- a/templates/mailman_vhost.conf
+++ b/templates/mailman_vhost.conf
@@ -27,10 +27,10 @@ server {
 {% endfor %}
 {% endif %}
 
-{% if exim4__mailman_use_ssl %}
-    location /.well_known {
-    	alias /var/www/html/.well_known;
+    location /.well-known {
+    	alias /var/www/html/.well-known;
     }
+{% if exim4__mailman_use_ssl %}
     
     return 301 https://$host$request_uri;
 }
@@ -55,6 +55,10 @@ server {
 	# ssl_prefer_server_ciphers on;
 	# ssl_session_cache shared:SSL:10m;
 	# ssl_session_timeout 5m;
+
+    location /.well-known {
+    	alias /var/www/html/.well-known;
+    }
 {% endif %}
 
     location / {


### PR DESCRIPTION
For certbot to be able to renew certs