### PR TITLE
Feat: Use other_hostnames as a variable

### DIFF
--- a/templates/update-exim4.conf.conf
+++ b/templates/update-exim4.conf.conf
@@ -17,7 +17,7 @@
 # This is a Debian specific file
 
 dc_eximconfig_configtype='{{ exim4__conf_type|default("local") }}'
-dc_other_hostnames=''
+dc_other_hostnames='{{ exim4__conf_other_hostnames|default("")}}'
 dc_local_interfaces='{% if exim4__conf_type|default("local") != "internet" %}127.0.0.1{% if exim4__conf_localip6|default(False) %} ; ::1{% endif %}{% endif %}'
 dc_readhost='{{ exim4__conf_readhost }}'
 dc_relay_domains=''


### PR DESCRIPTION
For outgoing mail being processed smartly, we have to specify
hostnames used by the machine.